### PR TITLE
static_image_demo.py now runs from command line with arguments

### DIFF
--- a/src/static_image_demo.py
+++ b/src/static_image_demo.py
@@ -1,7 +1,10 @@
 # cv2 - computer vision lib
 # mediapip - google's toolkit for applying AI to media
+import argparse
 import cv2
 import mediapipe as mp
+import numpy as np
+import os
 
 # shorthands for lib classes
 mp_pose = mp.solutions.pose
@@ -9,8 +12,27 @@ mp_drawing = mp.solutions.drawing_utils
 mp_drawing_styles = mp.solutions.drawing_styles
 pose = mp_pose.Pose(min_detection_confidence=0.5, min_tracking_confidence=0.5)
 
+
+def default_output_file_path(input_file):
+  root, ext = os.path.splitext(input_file)
+  out_path = root + '-output'
+  if ext != None:
+    out_path += ext
+  return out_path
+
+parser = argparse.ArgumentParser(
+                    prog='MT-Trainer static image demo',
+                    description='Estimates the pose of a single person in the given image, outputs an annotated image to the given file path, and optionally plots the landmarks in matplot3d')
+parser.add_argument('input_file')
+parser.add_argument('--output-file', '-o', dest='output_file') 
+parser.add_argument('--plot-3d', '-3d', dest='plot_3d', default='false', choices=['false','true']) 
+
+args = parser.parse_args()
+input_file=args.input_file
+output_file=args.output_file or default_output_file_path(input_file)
+
+
 # read the image
-input_file='/home/al/projects/aldavidson/mt-trainer/data/images/jom-kitti-front-teep-001.png'
 mp_image = mp.Image.create_from_file(input_file)
 
 # convert the image to the right format for pose recognition
@@ -19,13 +41,15 @@ converted_image = cv2.cvtColor(mp_image.numpy_view(), cv2.COLOR_BGR2RGB)
 # detect the pose
 results = pose.process(converted_image)
 
-# plot the pose as a connected skeleton in matlib3d
-mp_drawing.plot_landmarks(results.pose_world_landmarks, mp_pose.POSE_CONNECTIONS)
-
 # Draw landmarks on the image itself
 # Can only do this on a copy - the mp_image.numpy_view() is immutable
 annotated_image = np.copy(mp_image.numpy_view())
 converted_annotated_image = cv2.cvtColor(annotated_image, cv2.COLOR_BGR2RGB)
 mp_drawing.draw_landmarks(converted_annotated_image, results.pose_landmarks, mp_pose.POSE_CONNECTIONS, landmark_drawing_spec=mp_drawing_styles.get_default_pose_landmarks_style())
 # Save the annotated image
-cv2.imwrite('/home/al/projects/aldavidson/mt-trainer/output/jk2.jpg', converted_annotated_image)
+print('writing annotated image to ', output_file)
+cv2.imwrite(output_file, converted_annotated_image)
+
+# plot the pose as a connected skeleton in matlib3d
+if args.plot_3d == 'true':
+  mp_drawing.plot_landmarks(results.pose_world_landmarks, mp_pose.POSE_CONNECTIONS)


### PR DESCRIPTION
example output using `--help`:

```
$ python ./src/static_image_demo.py  --help
2024-01-08 17:23:39.778445: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /home/al/anaconda3/lib/python3.8/site-packages/cv2/../../lib64:
2024-01-08 17:23:39.778466: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1704734621.061141   33452 gl_context_egl.cc:85] Successfully initialized EGL. Major : 1 Minor: 5
I0000 00:00:1704734621.120488   33525 gl_context.cc:344] GL version: 3.2 (OpenGL ES 3.2 NVIDIA 545.23.08), renderer: NVIDIA GeForce RTX 2060/PCIe/SSE2
usage: MT-Trainer static image demo [-h] [--output-file OUTPUT_FILE] [--plot-3d {false,true}] input_file

Estimates the pose of a single person in the given image, outputs an annotated image to the given file path, and optionally plots the landmarks in matplot3d

positional arguments:
  input_file

optional arguments:
  -h, --help            show this help message and exit
  --output-file OUTPUT_FILE, -o OUTPUT_FILE
  --plot-3d {false,true}, -3d {false,true}

```